### PR TITLE
Plugins: add opt-in separate enable list per client

### DIFF
--- a/src/api/PluginManager.ts
+++ b/src/api/PluginManager.ts
@@ -29,6 +29,7 @@ import { addNicknameIcon, removeNicknameIcon } from "@api/NicknameIcons";
 import { Settings, SettingsStore } from "@api/Settings";
 import { disableStyle, enableStyle } from "@api/Styles";
 import { traceFunction } from "@debug/Tracer";
+import { localStorage } from "@utils/localStorage";
 import { Logger } from "@utils/Logger";
 import { onlyOnce } from "@utils/onlyOnce";
 import { canonicalizeFind, canonicalizeReplacement } from "@utils/patches";
@@ -43,15 +44,78 @@ const logger = new Logger("PluginManager", "#a6d189");
 
 export const PMLogger = logger;
 
+const CLIENT_PLUGINS_KEY = "Vencord_clientPlugins";
+
+interface ClientPlugins {
+    enabled: boolean;
+    plugins: Record<string, boolean>;
+}
+
+function loadClientPlugins(): ClientPlugins {
+    if (!IS_DISCORD_DESKTOP || IS_REPORTER) return { enabled: false, plugins: {} };
+
+    try {
+        const data = JSON.parse(localStorage.getItem(CLIENT_PLUGINS_KEY) ?? "null");
+        if (typeof data?.enabled === "boolean" && data.plugins && typeof data.plugins === "object")
+            return { enabled: data.enabled, plugins: data.plugins };
+    } catch { }
+
+    return { enabled: false, plugins: {} };
+}
+
+let clientPlugins = loadClientPlugins();
+const clientPluginsListeners = new Set<() => void>();
+
+function saveClientPlugins() {
+    localStorage.setItem(CLIENT_PLUGINS_KEY, JSON.stringify(clientPlugins));
+    clientPluginsListeners.forEach(l => l());
+}
+
+export function isSeparatePluginListEnabled() {
+    return IS_DISCORD_DESKTOP && !IS_REPORTER && clientPlugins.enabled;
+}
+
+export function subscribeClientPlugins(cb: () => void) {
+    clientPluginsListeners.add(cb);
+    return () => void clientPluginsListeners.delete(cb);
+}
+
+export function setPluginEnabled(p: string, enabled: boolean) {
+    if (isSeparatePluginListEnabled()) {
+        clientPlugins.plugins[p] = enabled;
+        saveClientPlugins();
+    } else {
+        (Settings.plugins[p] ??= { enabled }).enabled = enabled;
+    }
+}
+
+export function setSeparatePluginListEnabled(enabled: boolean) {
+    if (!IS_DISCORD_DESKTOP) return;
+
+    if (enabled && !Object.keys(clientPlugins.plugins).length) {
+        const plugins: Record<string, boolean> = {};
+        for (const name in Plugins)
+            plugins[name] = Settings.plugins[name].enabled;
+        clientPlugins.plugins = plugins;
+    }
+
+    clientPlugins.enabled = enabled;
+    saveClientPlugins();
+}
+
 /** Whether we have subscribed to flux events of all the enabled plugins when FluxDispatcher was ready */
 let enabledPluginsSubscribedFlux = false;
 const subscribedFluxEventsPlugins = new Set<string>();
 
 export function isPluginEnabled(p: string) {
+    const enabled = isSeparatePluginListEnabled()
+        ? clientPlugins.plugins[p] ?? Plugins[p]?.enabledByDefault ?? false
+        : Settings.plugins[p]?.enabled;
+
     return (
         Plugins[p]?.required ||
         Plugins[p]?.isDependency ||
-        Settings.plugins[p]?.enabled
+        enabled
     ) ?? false;
 }
 
@@ -132,17 +196,16 @@ export const startAllPlugins = traceFunction("startAllPlugins", function startAl
 });
 
 export function startDependenciesRecursive(p: Plugin) {
-    const settings = Settings.plugins;
     let restartNeeded = false;
     const failures: string[] = [];
 
     p.dependencies?.forEach(d => {
-        if (!settings[d].enabled) {
+        if (!isPluginEnabled(d)) {
             const dep = Plugins[d];
             startDependenciesRecursive(dep);
 
             // If the plugin has patches, don't start the plugin, just enable it.
-            settings[d].enabled = true;
+            setPluginEnabled(d, true);
             dep.isDependency = true;
 
             if (pluginRequiresRestart(dep)) {
@@ -331,7 +394,6 @@ export const stopPlugin = traceFunction("stopPlugin", function stopPlugin(p: Plu
 
 export const initPluginManager = onlyOnce(function init() {
     const pluginsValues = Object.values(Plugins);
-    const settings = Settings.plugins;
 
     const pluginKeysToBind: Array<keyof PluginDef & `${"on" | "render"}${string}`> = [
         "onBeforeMessageEdit", "onBeforeMessageSend", "onMessageClick",
@@ -356,7 +418,7 @@ export const initPluginManager = onlyOnce(function init() {
                 return;
             }
 
-            settings[d].enabled = true;
+            setPluginEnabled(d, true);
             dep.isDependency = true;
         });
 
@@ -377,7 +439,7 @@ export const initPluginManager = onlyOnce(function init() {
 
     for (const p of neededApiPlugins) {
         Plugins[p].isDependency = true;
-        settings[p].enabled = true;
+        setPluginEnabled(p, true);
     }
 
     for (const p of pluginsValues) {

--- a/src/components/settings/tabs/plugins/PluginCard.tsx
+++ b/src/components/settings/tabs/plugins/PluginCard.tsx
@@ -5,8 +5,7 @@
  */
 
 import { showNotice } from "@api/Notices";
-import { hasAnyVisibleSettings, isPluginEnabled, pluginRequiresRestart, startDependenciesRecursive, startPlugin, stopPlugin } from "@api/PluginManager";
-import { Settings } from "@api/Settings";
+import { hasAnyVisibleSettings, isPluginEnabled, pluginRequiresRestart, setPluginEnabled, startDependenciesRecursive, startPlugin, stopPlugin } from "@api/PluginManager";
 import { CogWheel, InfoIcon } from "@components/Icons";
 import { AddonCard } from "@components/settings/AddonCard";
 import { Plugin } from "@utils/types";
@@ -23,8 +22,6 @@ interface PluginCardProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 export function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, onMouseLeave, isNew }: PluginCardProps) {
-    const settings = Settings.plugins[plugin.name];
-
     const isEnabled = () => isPluginEnabled(plugin.name);
 
     function toggleEnabled() {
@@ -42,7 +39,7 @@ export function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, on
 
             if (restartNeeded) {
                 // If any dependencies have patches, don't start the plugin yet.
-                settings.enabled = true;
+                setPluginEnabled(plugin.name, true);
                 onRestartNeeded(plugin.name, "enabled");
                 return;
             }
@@ -50,21 +47,21 @@ export function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, on
 
         // if the plugin requires a restart, don't use stopPlugin/startPlugin. Wait for restart to apply changes.
         if (pluginRequiresRestart(plugin)) {
-            settings.enabled = !wasEnabled;
+            setPluginEnabled(plugin.name, !wasEnabled);
             onRestartNeeded(plugin.name, "enabled");
             return;
         }
 
         // If the plugin is enabled, but hasn't been started, then we can just toggle it off.
         if (wasEnabled && !plugin.started) {
-            settings.enabled = !wasEnabled;
+            setPluginEnabled(plugin.name, !wasEnabled);
             return;
         }
 
         const result = wasEnabled ? stopPlugin(plugin) : startPlugin(plugin);
 
         if (!result) {
-            settings.enabled = false;
+            setPluginEnabled(plugin.name, false);
 
             const msg = `Error while ${wasEnabled ? "stopping" : "starting"} plugin ${plugin.name}`;
             showToast(msg, Toasts.Type.FAILURE, {
@@ -74,7 +71,7 @@ export function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, on
             return;
         }
 
-        settings.enabled = !wasEnabled;
+        setPluginEnabled(plugin.name, !wasEnabled);
     }
 
     return (

--- a/src/components/settings/tabs/plugins/index.tsx
+++ b/src/components/settings/tabs/plugins/index.tsx
@@ -19,11 +19,12 @@
 import "./styles.css";
 
 import * as DataStore from "@api/DataStore";
-import { isPluginEnabled } from "@api/PluginManager";
+import { isPluginEnabled, isSeparatePluginListEnabled, setSeparatePluginListEnabled, subscribeClientPlugins } from "@api/PluginManager";
 import { useSettings } from "@api/Settings";
 import { Card } from "@components/Card";
 import { Divider } from "@components/Divider";
 import ErrorBoundary from "@components/ErrorBoundary";
+import { FormSwitch } from "@components/FormSwitch";
 import { HeadingTertiary } from "@components/Heading";
 import { Paragraph } from "@components/Paragraph";
 import { SettingsTab, wrapTab } from "@components/settings/tabs/BaseTab";
@@ -35,7 +36,7 @@ import { Margins } from "@utils/margins";
 import { classes } from "@utils/misc";
 import { useAwaiter, useCleanupEffect } from "@utils/react";
 import { PluginTag, PluginTags } from "@utils/types";
-import { Button, ConfirmModal,lodash, openModal, Parser, React, SearchableSelect, Select, TextInput, Tooltip, useMemo, useRef, useState } from "@webpack/common";
+import { Button, ConfirmModal, lodash, openModal, Parser, React, SearchableSelect, Select, TextInput, Tooltip, useEffect, useMemo, useReducer, useRef, useState } from "@webpack/common";
 import { JSX } from "react";
 
 import Plugins, { ExcludedPlugins, PluginMeta } from "~plugins";
@@ -115,7 +116,10 @@ function ExcludedPluginsList({ search }: { search: string; }) {
 }
 
 function PluginSettings() {
-    const settings = useSettings();
+    useSettings(["plugins.*"]);
+    const [, rerender] = useReducer(x => x + 1, 0);
+    useEffect(() => subscribeClientPlugins(rerender), []);
+
     const changeRef = useRef<ChangeList<string>>(null);
     const changes = changeRef.current ??= new ChangeList<string>();
 
@@ -229,12 +233,12 @@ function PluginSettings() {
 
         if (!pluginFilter(p)) continue;
 
-        const isRequired = p.required || p.isDependency || depMap[p.name]?.some(d => settings.plugins[d].enabled);
+        const isRequired = p.required || p.isDependency || depMap[p.name]?.some(isPluginEnabled);
 
         if (isRequired) {
             const tooltipText = p.required || !depMap[p.name]
                 ? "This plugin is required for Vencord to function."
-                : makeDependencyList(depMap[p.name]?.filter(d => settings.plugins[d].enabled));
+                : makeDependencyList(depMap[p.name]?.filter(isPluginEnabled));
 
             requiredPlugins.push(
                 <Tooltip text={tooltipText} key={p.name}>
@@ -266,6 +270,18 @@ function PluginSettings() {
     return (
         <SettingsTab>
             <ReloadRequiredCard required={changes.hasChanges} />
+
+            {IS_DISCORD_DESKTOP && (
+                <FormSwitch
+                    title="Separate plugin list"
+                    description="Keep which plugins are enabled local to this install. Their settings still sync."
+                    value={isSeparatePluginListEnabled()}
+                    onChange={enabled => {
+                        setSeparatePluginListEnabled(enabled);
+                        changes.handleChange("Separate plugin list");
+                    }}
+                />
+            )}
 
             <UIElementsButton />
 

--- a/src/plugins/consoleShortcuts/index.ts
+++ b/src/plugins/consoleShortcuts/index.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { setPluginEnabled } from "@api/PluginManager";
 import { loadLazyChunks } from "@debug/loadLazyChunks";
 import { Devs } from "@utils/constants";
 import { getCurrentChannel, getCurrentGuild } from "@utils/discord";
@@ -166,7 +167,7 @@ function makeShortcuts() {
             doc.addEventListener("close", () => root.unmount(), { once: true });
         },
 
-        preEnable: (plugin: string) => (Vencord.Settings.plugins[plugin] ??= { enabled: true }).enabled = true,
+        preEnable: (plugin: string) => setPluginEnabled(plugin, true),
 
         channel: { getter: () => getCurrentChannel(), preload: false },
         channelId: { getter: () => Common.SelectedChannelStore.getChannelId(), preload: false },


### PR DESCRIPTION
## Summary
- Adds an opt-in desktop toggle so each Discord client can keep its own plugin enable list
- Plugin options still sync as before; only `enabled` can be local (`localStorage` overlay in PluginManager)

## Test plan
- [ ] Toggle off: enables still sync between clients
- [ ] Toggle on: enables stay local to that client
- [ ] Plugin options still sync with toggle on
- [ ] Restart Discord: overlay survives
- [ ] Dependencies / required plugins still work

Please rewrite this description in your own words before expecting a review (Vencord CONTRIBUTING: no AI-written PR text).

Made with [Cursor](https://cursor.com)